### PR TITLE
Fix signup flow to avoid unauthenticated dashboard fetches

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -19,6 +19,11 @@ const Header = ({ isLanding = false }) => {
   // Fetch unread notification count
   useEffect(() => {
     if (!isLanding) {
+      const token = localStorage.getItem('token');
+      if (!token) {
+        return;
+      }
+
       fetchCurrentUser();
       fetchUnreadCount();
       fetchPendingInvitations();
@@ -34,7 +39,9 @@ const Header = ({ isLanding = false }) => {
   const fetchCurrentUser = async () => {
     try {
       const user = await getCurrentUser();
-      setCurrentUser(user);
+      if (user) {
+        setCurrentUser(user);
+      }
     } catch (error) {
       console.error('Error fetching current user:', error);
     }

--- a/frontend/src/pages/SignupForm.jsx
+++ b/frontend/src/pages/SignupForm.jsx
@@ -37,13 +37,9 @@ export default function SignupForm() {
     try {
       const msg = await signup(username, email, password);
       setMessage(msg);
-      // Redirect to Launchpad after successful signup
-      // Check for successful signup messages
-      if (msg.includes('registered') || msg.includes('success') || msg.includes('created') || (!msg.includes('error') && !msg.includes('failed'))) {
-        setTimeout(() => {
-          navigate("/launchpad");
-        }, 1000);
-      }
+      setTimeout(() => {
+        navigate("/login");
+      }, 1000);
     } catch (err) {
       setMessage(err.message);
     } finally {

--- a/frontend/src/services/AuthService.js
+++ b/frontend/src/services/AuthService.js
@@ -26,9 +26,7 @@ export async function login(username, password) {
 
 export async function getCurrentUser() {
   const token = localStorage.getItem('token');
-  if (!token) {
-    throw new Error('No token found');
-  }
+  if (!token) return null;
 
   const res = await fetch(`${API_BASE_URL}/api/user/me`, {
     headers: {


### PR DESCRIPTION
This PR fixes the signup flow so newly registered users are no longer redirected into the authenticated dashboard before they have a token as mentioned in the issue #47. That redirect was causing the app to mount authenticated layout code and log No token found during current-user initialization.

### What changed

- Changed signup success handling to route users to `/login` instead of `/launchpad`.
- Updated the header auth bootstrap to skip current-user and notification fetches when no token exists.
- Made the current-user helper return null when unauthenticated instead of throwing.

### Why

- Registration does not issue a token, so sending users directly into authenticated pages caused avoidable runtime noise and failed API calls.
- The new behavior keeps unauthenticated users on the public flow until they actually log in.

### Validation

npm run build in `frontend` completed successfully.